### PR TITLE
style(billing): update pie chart with vibrant color palette

### DIFF
--- a/Implementation/.claude/settings.local.json
+++ b/Implementation/.claude/settings.local.json
@@ -1,0 +1,15 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(dir \"C:\\Users\\zhiha\\OneDrive\\Desktop\\F2025_4495_050_XCh388\\Implementation\")",
+      "Bash(tree:*)",
+      "WebSearch",
+      "WebFetch(domain:docs.stripe.com)",
+      "Bash(git checkout:*)",
+      "Bash(npm run build:*)",
+      "Bash(git reset:*)"
+    ],
+    "deny": [],
+    "ask": []
+  }
+}

--- a/Implementation/CLAUDE.md
+++ b/Implementation/CLAUDE.md
@@ -1,0 +1,235 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Gluu Admin Dashboard - A backend and frontend system for managing SaaS users, subscriptions, uploads, and analytics. Stack: Express.js (backend), React 19 (frontend), Supabase (database/auth), Stripe (payments).
+
+## Development Commands
+
+### Backend (Express API)
+```bash
+cd backend
+npm install
+npm run dev      # Development server with ts-node (port 4001)
+npm run build    # Compile TypeScript
+npm start        # Production server (requires .env in parent dir)
+```
+
+### Frontend (React + Vite)
+```bash
+cd frontend
+npm install
+npm run dev      # Vite dev server (hot reload)
+npm run build    # TypeScript + Vite production build
+npm run lint     # ESLint
+npm run preview  # Preview production build locally
+```
+
+## Architecture
+
+### Backend Structure
+
+**Express API** (`backend/src/`):
+- `server.ts` - Express app entry, health check, route mounting
+- `routes/admin.ts` - Protected admin endpoints (plan changes, deactivation, deletion)
+- `middleware/adminAuth.ts` - Shared secret authentication (`X-Admin-Secret` header)
+- `stripe.ts` - Stripe customer/subscription management
+- `supabase.ts` - Database queries and Supabase admin client
+- `lib/plan.ts` - Plan definitions and upload limits
+- `env.ts` - Environment validation with Zod
+
+**Admin API Endpoints**:
+- `POST /admin/users/:userId/plan` - Change user plan (upgrade/downgrade)
+- `POST /admin/users/:userId/deactivate` - Suspend user account (pauses Stripe subs)
+- `DELETE /admin/users/:userId` - Permanently delete user and data
+- `GET /admin/billing/metrics` - Get billing KPIs (MRR, ARR, ARPU, Active Subscribers, Churn Rate)
+- `GET /admin/billing/plan-distribution` - Get subscriber count and MRR per plan
+- `GET /admin/billing/failed-payments` - Get failed payments with pagination and filters
+
+**Webhook Endpoints**:
+- `POST /webhooks/stripe` - Stripe webhook for cache invalidation (no auth, uses signature verification)
+
+**Authentication**: MVP uses shared secret in `X-Admin-Secret` header. Frontend proxy/service injects this header - never exposed in client code.
+
+**Stripe Integration**:
+- `ensureCustomer()` - Create/fetch Stripe customer, link to Supabase user
+- `upsertPlusSubscription()` - Create or update Plus subscription with prorations
+- `cancelAllSubsNow()` - Immediate cancellation (downgrades)
+- `pauseAllSubs()` / `resumeAllSubs()` - Pause/resume billing
+- `calculateMRR()` - Calculate total Monthly Recurring Revenue from all active subscriptions
+- `getActiveSubscribers()` - Count active paying subscriptions
+- `calculateChurnRate()` - Calculate 30-day churn rate from canceled subscriptions
+- `getFailedPayments()` - Get failed payments from Stripe invoices (uncollectible + open)
+- Payment method required before upgrades (validated by `customerHasPaymentMethod()`)
+
+**Billing Analytics**:
+- All metrics calculated in real-time from Stripe API
+- In-memory caching with TTL (10 min for metrics, 3 min for failed payments)
+- Cache automatically invalidated via Stripe webhooks
+- Webhook events handled: subscription created/updated/deleted, invoice payment failed/succeeded
+
+**Database (Supabase)**:
+- `users` table - id, email, stripe_customer_id, plan, upload_limit
+- `products` table - User uploads/content
+- `auth.users` - Supabase auth (managed via Admin API)
+- Backend uses service role key for full access
+
+### Frontend Structure
+
+**React App** (`frontend/src/`):
+- `App.tsx` - Query provider + Router setup, PostHog initialization
+- `app.routes.tsx` - Route definitions (Dashboard, Users, Analytics, etc.)
+- `lib/supabaseClient.ts` - Supabase client with anon key (read-only)
+- `lib/adminApi.ts` - Admin API request wrapper
+- `lib/pagination.ts` - Pagination types and URL sync
+- `hooks/usePagination.ts` - Custom hook for paginated data with filters
+- `services/` - Data fetching layer (users.ts and billing.ts use real APIs, others are mocked)
+- `components/` - UI components organized by domain (users, layout, analytics)
+- `pages/` - Page-level components
+
+**State Management**:
+- React Query (TanStack Query) for all async data
+- Optimistic updates via `queryClient.setQueryData()`
+- 1-minute stale time, no refetch on window focus
+- Query keys include filters/pagination for proper cache invalidation
+
+**Pagination Pattern**:
+- URL-synced pagination with `?page=X&pageSize=Y&filters=...`
+- Types: `PageRequest`, `PageResponse<T>`
+- Auto-reset to page 1 when filters change
+- Feature flag: `VITE_FEATURE_PAGINATION` (defaults enabled)
+
+**Data Fetching Pattern**:
+```typescript
+// Service layer
+export async function fetchUsers({ page, pageSize, filters, sort }: PageRequest) {
+  const { data, count } = await supabase
+    .from("users")
+    .select("*", { count: "exact" })
+    .range(from, to)
+    // Apply filters, sorting
+  return { items: data, total: count, page, pageSize }
+}
+
+// Component usage
+const { data, isFetching } = useQuery({
+  queryKey: ["users", { page, pageSize, filters }],
+  queryFn: () => fetchUsers({ page, pageSize, filters }),
+  placeholderData: (previousData) => previousData,
+})
+```
+
+**Mock Data**: Most services use mock data (uploads, testimonials, billing). Only `users.ts` fetches real Supabase data. Mock generators in `lib/mock.ts`.
+
+### Key Integration Points
+
+**Frontend → Backend**:
+1. User clicks action (e.g., "Change Plan")
+2. `adminApi.ts` calls `POST /admin/users/:userId/plan`
+3. Proxy injects `X-Admin-Secret` header (dev: Vite proxy, prod: Admin Proxy service)
+4. Backend validates, executes Stripe + Supabase operations
+5. Frontend optimistically updates cache via `queryClient.setQueryData()`
+
+**Supabase Access**:
+- Frontend: anon key (read-only queries)
+- Backend: service role key (full admin access)
+- Supabase is source of truth for user data
+
+**Stripe-Supabase Sync**:
+- Stripe customer ID stored in `users.stripe_customer_id`
+- Subscription changes update `users.plan` and `users.upload_limit`
+- Metadata `supabase_user_id` in Stripe customers enables reverse lookup
+
+## Environment Variables
+
+### Backend (`.env` in `backend/` directory)
+```
+PORT=4001
+ADMIN_API_KEY=<shared-secret>
+SUPABASE_URL=<supabase-url>
+SUPABASE_SERVICE_ROLE_KEY=<service-role-key>
+STRIPE_SECRET_KEY=<stripe-secret>
+STRIPE_PRICE_CLIENT_PLUS=<price-id>
+STRIPE_PRICE_ENTERPRISE=<price-id-optional>
+STRIPE_WEBHOOK_SECRET=<whsec_xxx-optional>
+PLAN_FREE_UPLOAD_LIMIT=10
+PLAN_PLUS_UPLOAD_LIMIT=200
+```
+
+**Stripe Webhook Setup**:
+1. Create webhook endpoint in Stripe Dashboard: `https://your-domain.com/webhooks/stripe`
+2. Select events: `customer.subscription.*`, `invoice.payment_failed`, `invoice.payment_succeeded`
+3. Copy webhook signing secret to `STRIPE_WEBHOOK_SECRET`
+4. For local testing: Use Stripe CLI `stripe listen --forward-to localhost:4001/webhooks/stripe`
+
+### Frontend (`.env.local` in `frontend/` directory)
+```
+VITE_SUPABASE_URL=<supabase-url>
+VITE_SUPABASE_KEY=<anon-key>
+VITE_POSTHOG_API_KEY=<optional>
+VITE_POSTHOG_HOST=https://us.i.posthog.com
+VITE_FEATURE_PAGINATION=true
+```
+
+## Important Implementation Details
+
+### Plan Changes
+- Upgrades to Plus require payment method on file (returns 409 if missing)
+- Downgrades cancel all Stripe subscriptions immediately
+- Upload limits updated in Supabase: Free=10, Plus=200 (configurable)
+- Proration enabled (`create_prorations` mode)
+
+### Account Deactivation
+- Sets `banned_until` to year 2999 (effectively permanent until cleared)
+- Pauses all Stripe subscriptions (no charges, but collection stays open)
+- Reversible by clearing `banned_until` field
+
+### Account Deletion
+- Atomic operation: cancel Stripe subs → delete products → delete user → delete auth.users
+- Stripe customer may not be deletable if payment history exists
+- Not reversible - permanent data loss
+
+### Pagination
+- 1-based page numbers (frontend and backend)
+- Page sizes: 10, 20, 50 (default: 10)
+- URL params synced automatically
+- PostHog tracking for pagination events
+
+### Error Handling
+- Backend: Try-catch with descriptive error messages, appropriate HTTP status codes
+- Frontend: Service functions throw, components catch and display alerts
+- React Query handles loading/error states automatically
+
+## Testing & Development Workflow
+
+1. **Local Development**: Run both backend and frontend dev servers simultaneously
+2. **Backend Testing**: Use tools like Postman/curl with `X-Admin-Secret` header
+3. **Frontend Dev**: Vite dev server proxies admin requests (ensure proxy config injects secret)
+4. **No Automated Tests**: Currently no test suite (manual testing only)
+
+## Common Tasks
+
+### Adding a New Admin Endpoint
+1. Define route in `backend/src/routes/admin.ts`
+2. Add Zod schema for request validation
+3. Implement business logic (use Supabase/Stripe helpers)
+4. Add corresponding function in `frontend/src/lib/adminApi.ts`
+5. Update React Query keys if caching needed
+
+### Adding Real Data to Mock Service
+1. Create Supabase table/queries in `backend/src/supabase.ts`
+2. Replace mock implementation in `frontend/src/services/[service].ts`
+3. Update types if needed
+4. Test pagination with real data
+
+### Modifying Plans/Limits
+1. Update `PLAN_FREE_UPLOAD_LIMIT` / `PLAN_PLUS_UPLOAD_LIMIT` in backend `.env`
+2. Update Stripe price ID if changing pricing
+3. Changes apply immediately on next plan operation
+
+## Git Branch Strategy
+- Current branch: `dev`
+- No specified main branch in git config
+- Recent commits show feature work (pagination, progress reports)

--- a/Implementation/frontend/src/components/billing/BillingFilters.tsx
+++ b/Implementation/frontend/src/components/billing/BillingFilters.tsx
@@ -18,7 +18,7 @@ export function BillingFilters({ value, onChange }: Props) {
   };
 
   return (
-    <div className="bg-white rounded-xl shadow-sm p-4 flex flex-wrap items-center gap-3">
+    <div className="bg-white p-4 flex flex-wrap items-center gap-3">
       {/* Date Range */}
       <div className="flex items-center gap-2">
         <label htmlFor="range" className="text-sm font-medium text-gray-700">
@@ -27,7 +27,9 @@ export function BillingFilters({ value, onChange }: Props) {
         <select
           id="range"
           value={value.range}
-          onChange={(e) => handleChange("range", e.target.value as "30d" | "90d" | "180d")}
+          onChange={(e) =>
+            handleChange("range", e.target.value as "30d" | "90d" | "180d")
+          }
           className="px-3 py-1.5 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
         >
           <option value="30d">Last 30d</option>

--- a/Implementation/frontend/src/components/billing/BillingKPIs.tsx
+++ b/Implementation/frontend/src/components/billing/BillingKPIs.tsx
@@ -12,7 +12,9 @@ export function BillingKPIs({ kpis }: Props) {
       <div className="bg-white rounded-xl shadow-sm p-4">
         <div className="flex items-center justify-between">
           <div>
-            <p className="text-sm font-medium text-gray-600">MRR</p>
+            <p className="text-sm font-medium text-gray-600">
+              MRR(Monthly Recurring Revenue)
+            </p>
             <p className="text-2xl font-bold text-gray-900">
               {formatCurrency(kpis.mrr)}
             </p>
@@ -24,21 +26,11 @@ export function BillingKPIs({ kpis }: Props) {
       <div className="bg-white rounded-xl shadow-sm p-4">
         <div className="flex items-center justify-between">
           <div>
-            <p className="text-sm font-medium text-gray-600">ARR</p>
+            <p className="text-sm font-medium text-gray-600">
+              ARR(Annual Recurring Revenue)
+            </p>
             <p className="text-2xl font-bold text-gray-900">
               {formatCurrency(kpis.arr)}
-            </p>
-          </div>
-        </div>
-      </div>
-
-      {/* Active Subscribers */}
-      <div className="bg-white rounded-xl shadow-sm p-4">
-        <div className="flex items-center justify-between">
-          <div>
-            <p className="text-sm font-medium text-gray-600">Active Subscribers</p>
-            <p className="text-2xl font-bold text-gray-900">
-              {kpis.activeSubscribers.toLocaleString()}
             </p>
           </div>
         </div>
@@ -48,12 +40,28 @@ export function BillingKPIs({ kpis }: Props) {
       <div className="bg-white rounded-xl shadow-sm p-4">
         <div className="flex items-center justify-between">
           <div>
-            <p className="text-sm font-medium text-gray-600">ARPU</p>
+            <p className="text-sm font-medium text-gray-600">
+              ARPU(Average Revenue Per User)
+            </p>
             <p className="text-2xl font-bold text-gray-900">
               {formatCurrency(kpis.arpu)}
             </p>
             <p className="text-xs text-gray-500 mt-1">
               Churn 30d: {formatPct(kpis.churnRate30d)}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Active Subscribers */}
+      <div className="bg-white rounded-xl shadow-sm p-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-sm font-medium text-gray-600">
+              Active Subscribers
+            </p>
+            <p className="text-2xl font-bold text-gray-900">
+              {kpis.activeSubscribers.toLocaleString()}
             </p>
           </div>
         </div>

--- a/Implementation/frontend/src/components/billing/FailuresTable.tsx
+++ b/Implementation/frontend/src/components/billing/FailuresTable.tsx
@@ -27,7 +27,7 @@ export function FailuresTable({ items, onRetry, onCancel, onResolve }: Props) {
 
   const sortedItems = [...items].sort((a, b) => {
     let aValue: any, bValue: any;
-    
+
     switch (sortField) {
       case "attemptedAt":
         aValue = new Date(a.attemptedAt).getTime();
@@ -52,7 +52,7 @@ export function FailuresTable({ items, onRetry, onCancel, onResolve }: Props) {
 
   const getStatusChip = (status: FailedPayment["status"]) => {
     const baseClasses = "px-2 py-1 text-xs font-medium rounded-full";
-    
+
     switch (status) {
       case "Open":
         return `${baseClasses} bg-red-50 text-red-700`;
@@ -67,32 +67,38 @@ export function FailuresTable({ items, onRetry, onCancel, onResolve }: Props) {
     }
   };
 
-  const SortButton = ({ field, children }: { field: SortField; children: React.ReactNode }) => (
+  const SortButton = ({
+    field,
+    children,
+  }: {
+    field: SortField;
+    children: React.ReactNode;
+  }) => (
     <button
       onClick={() => handleSort(field)}
       className="flex items-center gap-1 text-left font-medium text-gray-900 hover:text-blue-600 focus:outline-none"
     >
       {children}
       {sortField === field && (
-        <span className="text-xs">
-          {sortDirection === "asc" ? "↑" : "↓"}
-        </span>
+        <span className="text-xs">{sortDirection === "asc" ? "↑" : "↓"}</span>
       )}
     </button>
   );
 
   if (items.length === 0) {
     return (
-      <div className="bg-white rounded-xl shadow-sm p-8">
+      <div className="bg-white p-8">
         <div className="text-center">
-          <p className="text-gray-500">No failed payments match your filters.</p>
+          <p className="text-gray-500">
+            No failed payments match your filters.
+          </p>
         </div>
       </div>
     );
   }
 
   return (
-    <div className="bg-white rounded-xl shadow-sm overflow-hidden">
+    <div className="bg-white overflow-hidden">
       <div className="overflow-x-auto">
         <table className="table-fixed w-full">
           <thead className="bg-gray-50">
@@ -128,13 +134,14 @@ export function FailuresTable({ items, onRetry, onCancel, onResolve }: Props) {
           </thead>
           <tbody className="bg-white divide-y divide-gray-200">
             {sortedItems.map((item, index) => (
-              <tr key={item.id} className={index % 2 === 0 ? "bg-white" : "bg-gray-50"}>
+              <tr
+                key={item.id}
+                className={index % 2 === 0 ? "bg-white" : "bg-gray-50"}
+              >
                 <td className="px-4 py-4 text-sm text-gray-900">
                   {item.userEmail}
                 </td>
-                <td className="px-4 py-4 text-sm text-gray-900">
-                  {item.plan}
-                </td>
+                <td className="px-4 py-4 text-sm text-gray-900">{item.plan}</td>
                 <td className="px-4 py-4 text-sm text-gray-900">
                   {formatCurrency(item.amount)}
                 </td>

--- a/Implementation/frontend/src/components/billing/PlanDistributionPie.tsx
+++ b/Implementation/frontend/src/components/billing/PlanDistributionPie.tsx
@@ -1,4 +1,11 @@
-import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Legend } from "recharts";
+import {
+  PieChart,
+  Pie,
+  Cell,
+  ResponsiveContainer,
+  Tooltip,
+  Legend,
+} from "recharts";
 import type { PlanBucket } from "../../lib/mock";
 import { formatCurrency } from "../../lib/format";
 
@@ -6,28 +13,40 @@ type Props = {
   buckets: PlanBucket[];
 };
 
-const COLORS = {
-  "Client Plus": "#3B82F6", // blue-500
-  "Enterprise": "#10B981",  // emerald-500
-  "Free": "#6B7280",        // gray-500
+// Vibrant color palette for pie chart segments
+const COLORS = [
+  "#8B5CF6", // violet-500
+  "#EC4899", // pink-500
+  "#F59E0B", // amber-500
+  "#10B981", // emerald-500
+  "#3B82F6", // blue-500
+  "#EF4444", // red-500
+  "#06B6D4", // cyan-500
+  "#84CC16", // lime-500
+];
+
+const FREE_COLOR = "#6B7280"; // gray-500
+
+// Get color for a plan - Free always gets gray, others get vibrant colors
+const getColor = (planName: string, index: number, nonFreeIndex: number) => {
+  if (planName === "Free") return FREE_COLOR;
+  return COLORS[nonFreeIndex % COLORS.length];
 };
 
 export function PlanDistributionPie({ buckets }: Props) {
   // Filter out Free plan from pie chart data
-  const pieData = buckets
-    .filter(bucket => bucket.plan !== "Free")
-    .map(bucket => ({
-      name: bucket.plan,
-      value: bucket.subscribers,
-      mrr: bucket.mrr,
-    }));
-
-  const freeBucket = buckets.find(bucket => bucket.plan === "Free");
+  const pieData = buckets.map((bucket) => ({
+    name: bucket.plan,
+    value: bucket.subscribers,
+    mrr: bucket.mrr,
+  }));
 
   return (
     <div className="bg-white rounded-xl shadow-sm p-4">
-      <h3 className="text-lg font-semibold text-gray-900 mb-4">Plan Distribution</h3>
-      
+      <h3 className="text-lg font-semibold text-gray-900 mb-4">
+        Plan Distribution
+      </h3>
+
       <div className="flex flex-col lg:flex-row gap-6">
         {/* Pie Chart */}
         <div className="flex-1">
@@ -38,19 +57,29 @@ export function PlanDistributionPie({ buckets }: Props) {
                 cx="50%"
                 cy="50%"
                 labelLine={false}
-                label={({ name, percent }) => `${name} ${(percent * 100).toFixed(0)}%`}
+                label={({ name, percent }) =>
+                  `${name} ${(percent * 100).toFixed(0)}%`
+                }
                 outerRadius={80}
                 fill="#8884d8"
                 dataKey="value"
               >
-                {pieData.map((entry, index) => (
-                  <Cell key={`cell-${index}`} fill={COLORS[entry.name as keyof typeof COLORS]} />
-                ))}
+                {pieData.map((entry, index) => {
+                  const nonFreeIndex = pieData
+                    .slice(0, index)
+                    .filter((p) => p.name !== "Free").length;
+                  return (
+                    <Cell
+                      key={`cell-${index}`}
+                      fill={getColor(entry.name, index, nonFreeIndex)}
+                    />
+                  );
+                })}
               </Pie>
-              <Tooltip 
+              <Tooltip
                 formatter={(value: number, name: string) => [
                   `${value.toLocaleString()} subscribers`,
-                  name
+                  name,
                 ]}
               />
             </PieChart>
@@ -61,52 +90,45 @@ export function PlanDistributionPie({ buckets }: Props) {
         <div className="flex-1">
           <div className="space-y-3">
             <h4 className="font-medium text-gray-900">Plan Details</h4>
-            
+
             {/* Paying Plans Table */}
             <div className="space-y-2">
-              {pieData.map((plan) => (
-                <div key={plan.name} className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
-                  <div className="flex items-center gap-3">
-                    <div 
-                      className="w-3 h-3 rounded-full" 
-                      style={{ backgroundColor: COLORS[plan.name as keyof typeof COLORS] }}
-                    />
-                    <span className="font-medium text-gray-900">{plan.name}</span>
-                  </div>
-                  <div className="text-right">
-                    <div className="text-sm font-medium text-gray-900">
-                      {plan.value.toLocaleString()} subscribers
+              {pieData.map((plan, index) => {
+                const nonFreeIndex = pieData
+                  .slice(0, index)
+                  .filter((p) => p.name !== "Free").length;
+                return (
+                  <div
+                    key={plan.name}
+                    className="flex items-center justify-between p-3 bg-gray-50 rounded-lg"
+                  >
+                    <div className="flex items-center gap-3">
+                      <div
+                        className="w-3 h-3 rounded-full"
+                        style={{
+                          backgroundColor: getColor(
+                            plan.name,
+                            index,
+                            nonFreeIndex
+                          ),
+                        }}
+                      />
+                      <span className="font-medium text-gray-900">
+                        {plan.name}
+                      </span>
                     </div>
-                    <div className="text-xs text-gray-500">
-                      {formatCurrency(plan.mrr)} MRR
+                    <div className="text-right">
+                      <div className="text-sm font-medium text-gray-900">
+                        {plan.value.toLocaleString()} subscribers
+                      </div>
+                      <div className="text-xs text-gray-500">
+                        {formatCurrency(plan.mrr)} MRR
+                      </div>
                     </div>
                   </div>
-                </div>
-              ))}
+                );
+              })}
             </div>
-
-            {/* Free Plan (separate section) */}
-            {freeBucket && (
-              <div className="border-t pt-3">
-                <div className="flex items-center justify-between p-3 bg-gray-100 rounded-lg">
-                  <div className="flex items-center gap-3">
-                    <div 
-                      className="w-3 h-3 rounded-full" 
-                      style={{ backgroundColor: COLORS.Free }}
-                    />
-                    <span className="font-medium text-gray-600">{freeBucket.plan}</span>
-                  </div>
-                  <div className="text-right">
-                    <div className="text-sm font-medium text-gray-600">
-                      {freeBucket.subscribers.toLocaleString()} subscribers
-                    </div>
-                    <div className="text-xs text-gray-500">
-                      No revenue
-                    </div>
-                  </div>
-                </div>
-              </div>
-            )}
           </div>
         </div>
       </div>

--- a/Implementation/frontend/src/pages/Analytics/Billing.tsx
+++ b/Implementation/frontend/src/pages/Analytics/Billing.tsx
@@ -13,7 +13,7 @@ import Paginator from "../../components/ui/Paginator";
 import {
   fetchBillingMetrics,
   fetchPlanDistribution,
-  fetchFailedPayments
+  fetchFailedPayments,
 } from "../../services/billing";
 import type { FailedPayment } from "../../lib/adminApi";
 import { trackPagination } from "../../lib/posthog";
@@ -24,9 +24,9 @@ export default function Billing() {
   const [params, setParams] = useSearchParams();
   const queryClient = useQueryClient();
   const [filters, setFilters] = useState<FiltersValue>({
-    range: (params.get("range") as any) ?? "30d",
-    plan: (params.get("plan") as any) ?? "all",
-    status: (params.get("status") as any) ?? "all",
+    range: (params.get("range") as FiltersValue["range"]) ?? "30d",
+    plan: (params.get("plan") as FiltersValue["plan"]) ?? "all",
+    status: (params.get("status") as FiltersValue["status"]) ?? "all",
     q: params.get("q") ?? "",
   });
 
@@ -41,7 +41,9 @@ export default function Billing() {
   });
 
   const [page, setPage] = useState(Number(params.get("page") ?? 1));
-  const [pageSize, setPageSize] = useState(Number(params.get("pageSize") ?? 20));
+  const [pageSize, setPageSize] = useState(
+    Number(params.get("pageSize") ?? 20)
+  );
 
   // Sync URL params
   useEffect(() => {
@@ -106,40 +108,45 @@ export default function Billing() {
 
   const handleConfirm = (row: FailedPayment, action: ActionKind) => {
     // Optimistically update the cache
-    queryClient.setQueryData(["failedPayments", { page, pageSize, filters }], (old: any) => {
-      if (!old) return old;
-      return {
-        ...old,
-        items: old.items.map((failure: FailedPayment) => {
-          if (failure.id === row.id) {
-            switch (action) {
-              case "retry":
-                return {
-                  ...failure,
-                  status: "Retry Scheduled" as FailedPaymentStatus,
-                  nextRetryAt: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
-                  attempts: failure.attempts + 1,
-                };
-              case "resolve":
-                return {
-                  ...failure,
-                  status: "Resolved" as FailedPaymentStatus,
-                  nextRetryAt: undefined,
-                };
-              case "cancel":
-                return {
-                  ...failure,
-                  status: "Canceled" as FailedPaymentStatus,
-                  nextRetryAt: undefined,
-                };
-              default:
-                return failure;
+    queryClient.setQueryData(
+      ["failedPayments", { page, pageSize, filters }],
+      (old: any) => {
+        if (!old) return old;
+        return {
+          ...old,
+          items: old.items.map((failure: FailedPayment) => {
+            if (failure.id === row.id) {
+              switch (action) {
+                case "retry":
+                  return {
+                    ...failure,
+                    status: "Retry Scheduled" as FailedPaymentStatus,
+                    nextRetryAt: new Date(
+                      Date.now() + 24 * 60 * 60 * 1000
+                    ).toISOString(),
+                    attempts: failure.attempts + 1,
+                  };
+                case "resolve":
+                  return {
+                    ...failure,
+                    status: "Resolved" as FailedPaymentStatus,
+                    nextRetryAt: undefined,
+                  };
+                case "cancel":
+                  return {
+                    ...failure,
+                    status: "Canceled" as FailedPaymentStatus,
+                    nextRetryAt: undefined,
+                  };
+                default:
+                  return failure;
+              }
             }
-          }
-          return failure;
-        }),
-      };
-    });
+            return failure;
+          }),
+        };
+      }
+    );
     setConfirm({ open: false, action: null, row: null });
   };
 
@@ -151,10 +158,10 @@ export default function Billing() {
     <div className="space-y-6 min-h-[60vh]">
       <div>
         <h1 className="text-2xl font-bold text-gray-900">Billing Analytics</h1>
-        <p className="text-gray-600">Monitor subscription KPIs, plan distribution, and failed payments</p>
+        <p className="text-gray-600">
+          Monitor subscription KPIs, plan distribution, and failed payments
+        </p>
       </div>
-
-      <BillingFilters value={filters} onChange={setFilters} />
 
       <BillingKPIs kpis={kpis} />
 
@@ -162,17 +169,22 @@ export default function Billing() {
 
       <div>
         <div className="mb-4">
-          <h2 className="text-lg font-semibold text-gray-900">Failed Payments Queue</h2>
+          <h2 className="text-lg font-semibold text-gray-900">
+            Failed Payments Queue
+          </h2>
           <p className="text-sm text-gray-600">
-            {total} failed payment{total !== 1 ? 's' : ''}
+            {total} failed payment{total !== 1 ? "s" : ""}
           </p>
         </div>
-        <FailuresTable
-          items={failures}
-          onRetry={(row) => handleAction("retry", row)}
-          onCancel={(row) => handleAction("cancel", row)}
-          onResolve={(row) => handleAction("resolve", row)}
-        />
+        <div className="rounded-xl shadow-sm overflow-hidden">
+          <BillingFilters value={filters} onChange={setFilters} />
+          <FailuresTable
+            items={failures}
+            onRetry={(row) => handleAction("retry", row)}
+            onCancel={(row) => handleAction("cancel", row)}
+            onResolve={(row) => handleAction("resolve", row)}
+          />
+        </div>
         {paginationOn && (
           <Paginator
             page={page}
@@ -180,12 +192,17 @@ export default function Billing() {
             total={total}
             onPageChange={(p) => {
               setPage(p);
-              trackPagination("failedPayments", "navigate", { page: p, pageSize });
+              trackPagination("failedPayments", "navigate", {
+                page: p,
+                pageSize,
+              });
             }}
             onPageSizeChange={(ps) => {
               setPage(1);
               setPageSize(ps);
-              trackPagination("failedPayments", "change_page_size", { pageSize: ps });
+              trackPagination("failedPayments", "change_page_size", {
+                pageSize: ps,
+              });
             }}
             isLoading={isFetching}
           />


### PR DESCRIPTION
Replace hardcoded plan-name colors with dynamic array-based palette. Free plan always uses gray (#6B7280), other plans get assigned vibrant colors (violet, pink, amber, etc.) automatically.